### PR TITLE
Update style.mss

### DIFF
--- a/style.mss
+++ b/style.mss
@@ -19,11 +19,11 @@
 @village_text:      #444;
 @village_halo:      @land;
 
-@sans:              'Fira Sans Regular','DejaVu Sans Book','Unifont Medium';
-@sans_bold:         'Fira Sans Bold','Unifont Medium';
-@sans_bold_italic:  'Fira Sans Bold Italic','Unifont Medium';
-@sans_light:        'Fira Sans Light','Unifont Medium';
-@sans_book:         'Fira Sans Book','Unifont Medium';
+@sans:              'Fira Sans Regular','DejaVu Sans Book','unifont Medium';
+@sans_bold:         'Fira Sans Bold','unifont Medium';
+@sans_bold_italic:  'Fira Sans Bold Italic','unifont Medium';
+@sans_light:        'Fira Sans Light','unifont Medium';
+@sans_book:         'Fira Sans Book','unifont Medium';
 
 
 /* *********** */


### PR DESCRIPTION
This update is due to case issue with font name. I'm using Ubuntu 14.04 64 bits 

I had warning like below

```
[httpserver] /node_modules/kosmtik-place-search/front/place-search.css 200
Mapnik LOG> 2015-07-12 00:55:55: warning: unable to find face-name 'Unifont Medium' in FontSet 'fontset-0'
Mapnik LOG> 2015-07-12 00:55:55: warning: unable to find face-name 'Unifont Medium' in FontSet 'fontset-1'
Mapnik LOG> 2015-07-12 00:55:55: warning: unable to find face-name 'Unifont Medium' in FontSet 'fontset-2'
```

After a `sudo apt-get install unifont`, the issue was the same. With the doubt, I tried to reload the font cache with `sudo fc-cache -f -v`.
Doing at the end, a `fc-list |grep nifont` indicated following

```
/usr/share/fonts/truetype/unifont/unifont.ttf: unifont:style=Medium
```

Doing the case change fixed the issue, hence this PR
